### PR TITLE
Add 'T:Send' to prevent UB

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -55,8 +55,8 @@ impl<T> Clone for SyncChannel<T> {
         }
     }
 }
-unsafe impl<T> Send for SyncChannel<T> {}
-unsafe impl<T> Sync for SyncChannel<T> {}
+unsafe impl<T: Send> Send for SyncChannel<T> {}
+unsafe impl<T: Send> Sync for SyncChannel<T> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Fixes #2

This PR adds `T: Send` bounds to the `Send`/`Sync` impls of `SyncChannel<T>`
in order to prevent users from sending non-Send types to other threads.

Thank you for reviewing this PR :+1: 